### PR TITLE
feat: add ObservationAttached and ObservationDetached event handlers

### DIFF
--- a/src/tasks_collector_tools/eventdump.py
+++ b/src/tasks_collector_tools/eventdump.py
@@ -48,13 +48,13 @@ EVENT_TEMPLATE = """
 TEMPLATE = """
 # {{ date }}
 {% if plan and plan.model.has_focus %}
-{{ plan.focus_list() }}
+{{ plan.focus_list }}
 {% endif %}
 
 {% if plan and plan.model.has_want %}
 ## Want
 
-{{ plan.want_list() }}
+{{ plan.want_list }}
 {% endif %}
 
 {% if habits %}

--- a/src/tasks_collector_tools/models.py
+++ b/src/tasks_collector_tools/models.py
@@ -37,12 +37,11 @@ class HabitTracked(BaseEvent):
 
 
 class ObservationEvent(BaseEvent):
-    url: str
-
+    event_stream_id: str
 
 class ObservationMade(ObservationEvent):
+    url: str
     resourcetype: Literal['ObservationMade']
-    event_stream_id: str
     type: str
     situation: str
     interpretation: Optional[str]
@@ -50,43 +49,54 @@ class ObservationMade(ObservationEvent):
 
 
 class ObservationUpdated(ObservationEvent):
+    url: str
     resourcetype: Literal['ObservationUpdated']
-    event_stream_id: str
     observation_id: Optional[int]
     situation_at_creation: str
     comment: str
 
 
 class ObservationRecontextualized(ObservationEvent):
+    url: str
     resourcetype: Literal['ObservationRecontextualized']
-    event_stream_id: str
     situation: str
     old_situation: str
 
 
 class ObservationReinterpreted(ObservationEvent):
+    url: str
     resourcetype: Literal['ObservationReinterpreted']
-    event_stream_id: str
     interpretation: Optional[str]
     old_interpretation: Optional[str]
     situation_at_creation: str
 
 
 class ObservationReflectedUpon(ObservationEvent):
+    url: str
     resourcetype: Literal['ObservationReflectedUpon']
-    event_stream_id: str
     approach: Optional[str]
     old_approach: Optional[str]
     situation_at_creation: str
 
 
 class ObservationClosed(ObservationEvent):
+    url: str
     resourcetype: Literal['ObservationClosed']
-    event_stream_id: str
     type: str
     situation: str
     interpretation: Optional[str]
     approach: Optional[str]
+
+
+class ObservationAttached(BaseEvent):
+    resourcetype: Literal['ObservationAttached']
+    other_event_stream_id: str
+    observation: Optional[int]
+
+
+class ObservationDetached(BaseEvent):
+    resourcetype: Literal['ObservationDetached']
+    other_event_stream_id: str
 
 
 class ProjectedOutcomeMade(BaseEvent):
@@ -174,6 +184,8 @@ Event = Union[
     ObservationReinterpreted, 
     ObservationReflectedUpon, 
     ObservationClosed,
+    ObservationAttached,
+    ObservationDetached,
     ProjectedOutcomeMade,
     ProjectedOutcomeRedefined,
     ProjectedOutcomeRescheduled,

--- a/src/tasks_collector_tools/presenters.py
+++ b/src/tasks_collector_tools/presenters.py
@@ -9,6 +9,7 @@ from .models import (
     BaseEvent, Habit, JournalAdded, HabitTracked, ObservationEvent,
     ObservationMade, ObservationUpdated, ObservationRecontextualized,
     ObservationReinterpreted, ObservationReflectedUpon, ObservationClosed,
+    ObservationAttached, ObservationDetached,
     ProjectedOutcomeMade, ProjectedOutcomeRedefined, ProjectedOutcomeRescheduled, ProjectedOutcomeClosed,
     Plan, Reflection, Event
 )
@@ -171,6 +172,21 @@ class ObservationClosedPresenter(BaseEventPresenter):
     {% endif %}
     """
 
+class ObservationAttachedPresenter(BaseEventPresenter):
+    template: str = """
+    Attached observation {{ observation_ref }} to thread {{ event.thread }}
+    """
+
+    def observation_ref(self):
+        if self.event.observation:
+            return f"#{self.event.observation}"
+        return self.event.other_event_stream_id
+
+class ObservationDetachedPresenter(BaseEventPresenter):
+    template: str = """
+    Detached observation {{ event.other_event_stream_id }} from thread {{ event.thread }}
+    """
+
 class ProjectedOutcomeMadePresenter(BaseEventPresenter):
     template: str = """
     **{{ event.name }}**
@@ -272,6 +288,10 @@ def get_presenter_class(event: Event):
             return ObservationReflectedUponPresenter
         case ObservationClosed():
             return ObservationClosedPresenter
+        case ObservationAttached():
+            return ObservationAttachedPresenter
+        case ObservationDetached():
+            return ObservationDetachedPresenter
         case ProjectedOutcomeMade():
             return ProjectedOutcomeMadePresenter
         case ProjectedOutcomeRedefined():


### PR DESCRIPTION
## Summary
- Add ObservationAttached and ObservationDetached models to handle observation thread associations  
- Create presenters for both event types with clear messaging
- Update Event union type and presenter factory to include new events

## Additional fixes
- Refactor ObservationEvent base class to include event_stream_id consistently
- Fix template rendering to support complex boolean conditions like `plan and plan.model.has_focus`
- Fix method calls in templates by removing parentheses (eventdump.py)

## Test plan
- [x] Verify ObservationAttached events are properly parsed and displayed
- [x] Verify ObservationDetached events are properly parsed and displayed  
- [x] Test eventdump and reflectiondump commands work without errors
- [x] Confirm template rendering handles boolean conditions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)