### PR TITLE
fix: ensure .tasks directory exists before writing to it

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,3 +38,4 @@
 - [ ] Add Areas
   - Reflection Weekly is separated in areas (journal tags)
   - Each Area has 
+- [x] Bug: ensure that .tasks exists before writing to it

--- a/src/tasks_collector_tools/observation.py
+++ b/src/tasks_collector_tools/observation.py
@@ -58,7 +58,7 @@ from pathlib import Path
 
 from .config.tasks import TasksConfigFile
 
-from .utils import sanitize_fields, SHORT_TIMEOUT
+from .utils import sanitize_fields, SHORT_TIMEOUT, ensure_directory_exists
 
 OBSERVATIONS_BACKUP_FILE = os.path.expanduser(os.path.join('~', '.tasks', 'observations_backup.json'))
 
@@ -113,6 +113,7 @@ def list_observations(config, chars=70, number=10, ownership='mine'):
 
         response = r.json()
 
+        ensure_directory_exists(OBSERVATIONS_BACKUP_FILE)
         with open(OBSERVATIONS_BACKUP_FILE, 'w') as f:
             json.dump(response, f)
     except (ConnectionError, ReadTimeout):

--- a/src/tasks_collector_tools/update.py
+++ b/src/tasks_collector_tools/update.py
@@ -38,6 +38,7 @@ from requests.auth import HTTPBasicAuth
 from pathlib import Path
 
 from .config.tasks import TasksConfigFile
+from .utils import queue_failed_request, retry_failed_requests
 
 
 def template_from_arguments(arguments):
@@ -63,7 +64,6 @@ def add_stack_to_payload(payload, name, lines):
 
 OBSERVATION_FILE_PATH = os.path.expanduser(os.path.join('~', '.observation_id'))
 
-DEAD_LETTER_DIRECTORY = os.path.expanduser(os.path.join('~', '.tasks', 'queue'))
 
 def get_saved_observation_id():
     try:
@@ -74,47 +74,6 @@ def get_saved_observation_id():
     
     return None
 
-def queue_dead_letter(payload, path, metadata):
-    if not os.path.exists(path):
-        os.makedirs(path)
-
-    basename = "{}".format(datetime.now().strftime("%Y-%m-%d_%H%M%S_update"))
-    name = f'{basename}.json'
-    i = 0
-
-    while os.path.exists(name):
-        i += 1
-        name = f'{basename}-{i}.json'
-
-    with open(os.path.join(path, name), "w") as f:
-        json.dump({
-            'payload': payload,
-            'meta': metadata
-        }, f)
-    
-    return name
-
-def send_dead_letter(path, _metadata):
-    metadata = _metadata.copy()
-
-    print(f"Attempting to send {path}...")
-
-    with open(path) as f:        
-        data = json.load(f)
-
-
-        metadata.update(data['meta'])
-        payload = data['payload']
-
-        requests.post(metadata['url'], json=payload, auth=metadata['auth'])
-
-    os.unlink(path)
-
-
-def send_dead_letters(path, metadata):
-    for root, dirs, files in os.walk(path):
-        for name in sorted(files):
-            send_dead_letter(os.path.join(root, name), metadata)
 
 def main():
     arguments = docopt(__doc__, version='1.0.2')
@@ -177,7 +136,7 @@ def main():
         sys.exit(0)
 
     try:
-        send_dead_letters(DEAD_LETTER_DIRECTORY, metadata={
+        retry_failed_requests(metadata={
             'auth': HTTPBasicAuth(config.user, config.password)
         })
     except Exception as e:
@@ -189,9 +148,9 @@ def main():
     try:
         r = requests.post(url, json=payload, auth=HTTPBasicAuth(config.user, config.password))
     except ConnectionError:
-        name = queue_dead_letter(payload, path=DEAD_LETTER_DIRECTORY, metadata={
-            'url': url,            
-        })
+        name = queue_failed_request(payload, metadata={
+            'url': url,
+        }, file_type="update")
 
         print("Error: Connection failed.")
         print(f"Your update was saved at {name}.")


### PR DESCRIPTION
## Summary
- Fix bug where `.tasks` directory needs to exist before writing files to it
- Centralize directory creation logic and dead letter management
- Remove code duplication across multiple files

## Changes Made
- **Fixed the core bug**: Added `ensure_directory_exists()` utility function that creates parent directories before file operations
- **Fixed observation.py**: Now ensures `.tasks` directory exists before writing `observations_backup.json`
- **Centralized constants**: Moved `DEAD_LETTER_DIRECTORY` from individual files to `utils.py`
- **Removed duplication**: Eliminated duplicate `queue_dead_letter`, `send_dead_letter`, and `send_dead_letters` functions across `reflect.py`, `journal.py`, and `update.py`
- **Clean API**: Added wrapper functions `queue_failed_request()` and `retry_failed_requests()` that hide implementation details from callers

## Files Modified
- `src/tasks_collector_tools/utils.py` - Added utility functions and centralized constants
- `src/tasks_collector_tools/observation.py` - Fixed directory creation bug
- `src/tasks_collector_tools/journal.py` - Updated to use centralized functions
- `src/tasks_collector_tools/reflect.py` - Updated to use centralized functions
- `src/tasks_collector_tools/update.py` - Updated to use centralized functions
- `TODO.md` - Marked bug as fixed

## Test Plan
- [x] Test observation command with clean system (no `.tasks` directory)
- [x] Test journal and update commands with network failures to verify dead letter queuing
- [x] Verify retry functionality works correctly
- [x] Confirm no duplicate code remains

🤖 Generated with [Claude Code](https://claude.ai/code)