### PR TITLE
feat: add stats command to display usage statistics

### DIFF
--- a/src/tasks_collector_tools/models.py
+++ b/src/tasks_collector_tools/models.py
@@ -223,4 +223,24 @@ class Result(BaseModel):
         if self.reflection and not self.reflection.empty():
             return False
 
-        return True 
+        return True
+
+
+class StatsResponse(BaseModel):
+    year: Optional[int]
+    years: List[int]
+    journal_count: int
+    habit_count: int
+    observation_count: int
+    observation_updated_count: int
+    observation_closed_count: int
+    event_count: int
+    observation_recontextualized_count: int
+    observation_reflected_upon_count: int
+    observation_reinterpreted_count: int
+    projected_outcome_made_count: int
+    projected_outcome_redefined_count: int
+    projected_outcome_rescheduled_count: int
+    projected_outcome_closed_count: int
+    word_count: int
+    word_count_updated: datetime 


### PR DESCRIPTION
## Summary
- Added new `stats` command to the tasks CLI that fetches and displays usage statistics from the Tasks Collector API
- Accepts optional year parameter to view statistics for a specific year, or shows all-time stats when no year is provided
- Created StatsResponse Pydantic model to parse the /stats/json/ API response
- Implemented formatted output displaying activity counts, observation metrics, projected outcome metrics, and word count

## Test plan
- [x] Run `stats` command without arguments to verify all-time statistics are displayed
- [x] Run `stats 2024` to verify year-specific statistics are displayed correctly
- [x] Verify all stat categories are properly formatted and aligned
- [x] Confirm error handling works for invalid API responses
- [x] Check that available years are listed at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)