### PR TITLE
refactor: migrate habit model from tagname to keywords

### DIFF
--- a/src/tasks_collector_tools/models.py
+++ b/src/tasks_collector_tools/models.py
@@ -20,8 +20,12 @@ class Habit(BaseModel):
     name: str
     description: Optional[str]
     slug: str
-    tagname: str
+    keywords: List[str]
+    tagname: Optional[str] = None # Deprecated
 
+
+class HabitWithTracked(Habit):
+    today_tracked: int
 
 class JournalAdded(BaseEvent):
     resourcetype: Literal['JournalAdded']

--- a/src/tasks_collector_tools/presenters.py
+++ b/src/tasks_collector_tools/presenters.py
@@ -85,11 +85,25 @@ class HabitTrackedPresenter(BaseEventPresenter):
 
         return f'- {self.nice_published()}: {self.get_note()}'
 
+    def get_keyword(self) -> str:
+        note = self.get_note()
+        
+        for keyword in self.event.habit.keywords:
+            if re.match(r'^[!#]' + keyword, note):
+                return keyword
+
+        if len(self.event.habit.keywords) > 0:
+            return self.event.habit.keywords[0]
+        
+        name = self.event.habit.name
+        raise ValueError(f"Habit {name} has no keywords")
+
     def get_note(self):
         if not self.event.note:
             occured_str = '#' if self.event.occured else '!'
+            keyword = self.get_keyword()
 
-            return f'{occured_str}{self.event.habit.tagname}'
+            return f'{occured_str}{keyword}'
         
         return self.event.note
 


### PR DESCRIPTION
## Summary

- Replaces single `tagname` field with `keywords` list in the Habit model to support multiple keywords per habit
- Adds `HabitWithTracked` model to separate tracking status from core habit data
- Updates habit formatting, filtering, and statistics to work with multiple keywords
- Improves keyword extraction in presenters to handle multiple keywords correctly

## Changes

### Models (`models.py`)
- **Habit model**: Changed `tagname: str` to `keywords: List[str]`, deprecated `tagname` field
- **New model**: Added `HabitWithTracked` that extends Habit with `today_tracked` field

### Habit Tracking (`habits.py`)
- Updated `format_habit_list()` to iterate over all keywords from all habits
- Refactored habit filtering to check keywords against ignore list
- Changed `Habit` dataclass usage to `HabitWithTracked` from models
- Updated prompts and formatting to use keywords instead of tagname

### Presenters (`presenters.py`)
- Added `get_keyword()` method to extract the correct keyword from tracked notes
- Updated `get_note()` to use keyword instead of tagname

### Statistics (`reflectiondump.py`)
- Refactored `HabitStatistics` to group by habit ID instead of tagname
- Created `HabitGroup` class to encapsulate habit grouping logic
- Updated statistics display to show habit name instead of tagname

## Test plan
- [x] Verify habits with single keyword work as before
- [x] Test habits with multiple keywords display all keywords
- [x] Check habit filtering respects ignore list for all keywords
- [x] Confirm statistics correctly group by habit regardless of keywords used
- [x] Validate backward compatibility with deprecated tagname field

🤖 Generated with [Claude Code](https://claude.com/claude-code)