### PR TITLE
refactor: remove deprecated tagname field from Habit model

### DIFF
--- a/src/tasks_collector_tools/models.py
+++ b/src/tasks_collector_tools/models.py
@@ -21,7 +21,6 @@ class Habit(BaseModel):
     description: Optional[str]
     slug: str
     keywords: List[str]
-    tagname: Optional[str] = None # Deprecated
 
 
 class HabitWithTracked(Habit):


### PR DESCRIPTION
## Summary

- Removes the deprecated `tagname` field from the Habit model
- Completes the migration to the `keywords` field introduced in the previous refactoring

## Changes

### Models (`models.py:24`)
- Removed `tagname: Optional[str] = None # Deprecated` from Habit model

This field was deprecated when we migrated to using a `keywords` list instead of a single `tagname` string. All code now uses the `keywords` field, so the deprecated field can be safely removed.

## Test plan
- [x] Verify application still works correctly with habits
- [x] Confirm no code references the removed tagname field
- [x] Check that API responses properly provide keywords field

🤖 Generated with [Claude Code](https://claude.com/claude-code)