### PR TITLE
feat: allow oedit command to open observations list without argument

### DIFF
--- a/src/tasks_collector_tools/tasks.py
+++ b/src/tasks_collector_tools/tasks.py
@@ -140,7 +140,10 @@ def change_thread(args, config):
 
 
 def open_observation(args, config):
-    subprocess.call(['open', f"{config.url}/observations/{args[0]}"])
+    if args:
+        subprocess.call(['open', f"{config.url}/observations/{args[0]}"])
+    else:
+        subprocess.call(['open', f"{config.url}/observations/"])
 
 
 def show_stats(args, config):


### PR DESCRIPTION
## Summary
- Enhanced the `oedit`/`edit` command to handle missing arguments gracefully
- When called without an argument, it now opens the general observations list page (`/observations/`)
- When called with an observation ID, it continues to open that specific observation as before

## Test plan
- [x] Test `oedit` without arguments - should open `/observations/` page
- [x] Test `oedit 123` with an ID - should open `/observations/123` page
- [x] Verify the command doesn't crash when no argument is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)