### PR TITLE
feat: add last event timestamp display to observation list

### DIFF
--- a/src/tasks_collector_tools/observationdump.py
+++ b/src/tasks_collector_tools/observationdump.py
@@ -73,6 +73,7 @@ class Observation:
     type: str = None
     thread: str = None
     published: datetime = None
+    last_event_published: datetime = None
     situation: str = None
     interpretation: str = None
     approach: str = None
@@ -232,7 +233,11 @@ def update_observation_with_event(observation: Observation, event: dict):
 
     if event['resourcetype'] in ('ObservationMade', 'ObservationClosed'):
         observation.published = event['published']
-    
+
+    # Track the last event timestamp
+    if observation.last_event_published is None or event['published'] > observation.last_event_published:
+        observation.last_event_published = event['published']
+
     if 'type' in event:
         observation.type = event['type']
     if 'thread' in event:
@@ -248,7 +253,7 @@ def update_observation_with_event(observation: Observation, event: dict):
         observation.closed = True
     if event['resourcetype'] == 'ObservationUpdated':
         observation.updates.append(event)
-    
+
     observation.events.append(event)
 
 


### PR DESCRIPTION
## Summary

- Added `last_event_published` field to the Observation dataclass to track when observations were last updated
- Implemented `time_ago()` function that displays elapsed time with up to 2 significant units (e.g., "2w 3d ago", "1d 23h ago")
- Updated observation list display to show time since last update when the field is available from the API

## Changes

### `src/tasks_collector_tools/observation.py`
- Added `time_ago()` function with recursive multi-unit time calculation
- Modified `list_observations()` to display time since last update in parentheses

### `src/tasks_collector_tools/observationdump.py`
- Added `last_event_published` field to `Observation` dataclass
- Updated `update_observation_with_event()` to track the most recent event timestamp

## Example Output

```
#123: User reported login issue with OAuth provider (2d 5h ago)
#124: Performance degradation in search endpoint (5h 23m ago)
#125: Database migration completed successfully (1w 3d ago)
```

## Backend Requirement

This feature expects the backend API to include a `last_event_published` field in the observation list response. The client code is backwards-compatible and will work without the field (simply not showing the time info).

🤖 Generated with [Claude Code](https://claude.com/claude-code)