### PR TITLE
feat: add color-coded time display and sorting by update time

### DIFF
--- a/src/tasks_collector_tools/observation.py
+++ b/src/tasks_collector_tools/observation.py
@@ -45,7 +45,7 @@ import json, os, re, sys
 
 from docopt import docopt
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import tempfile
 
@@ -54,8 +54,6 @@ import subprocess
 import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import ConnectionError, ReadTimeout
-
-from pathlib import Path
 
 from colored import fg, attr
 


### PR DESCRIPTION
## Summary

Enhanced observation list display with color-coded time indicators and optional sorting by last update time.

## Features

### 🎨 Color-Coded Time Display
Time since last update is now color-coded based on age:
- **Yellow**: < 1 week (current)
- **Green**: 1 week - 1 month (recent)
- **No color**: 1-3 months (stale)
- **Blue**: > 3 months (old)

### 🔄 Sort by Update Time
New `-u/--sort-by-update` flag to sort observations by `last_event_published` (most recent first).

Usage:
```bash
observation -l          # Default ordering
observation -lu         # Sorted by most recently updated
```

## Refactoring

### Code Quality Improvements
- **Extracted `parse_datetime_delta()`**: Centralized datetime parsing logic with identity function for int inputs
- **Separated concerns**: 
  - `time_ago()` - returns plain text
  - `time_ago_colored()` - adds color coding
- **Type hints**: Added for better readability and IDE support
- **Performance**: Avoid duplicate parsing by passing pre-calculated seconds

### Function Signatures
```python
def parse_datetime_delta(date_string_or_seconds: str | int | None) -> int | None
def time_ago(date_string_or_seconds: str | int | None) -> str
def time_ago_colored(date_string_or_seconds: str | int | None) -> str
```

## Example Output

```
#123: User authentication issue - 2d 3h ago  [yellow]
#124: Performance review needed - 2w 1d ago  [green]
#125: Documentation update - 2mo 3w ago     [no color]
#126: Initial architecture design - 5mo 2w ago  [blue]
```

## Dependencies

Uses existing `colored` library (already in project dependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)