### PR TITLE
refactor: switch habits to use /habit/keywords/mine/ endpoint

### DIFF
--- a/src/tasks_collector_tools/habits.py
+++ b/src/tasks_collector_tools/habits.py
@@ -77,13 +77,16 @@ def get_habit_list(config, stderr, date=None):
             stderr.write("HTTP {}\n{}".format(r.status_code, r.text) + '\n')
 
 
-def get_keyword_list(config, stderr, all_keywords=False):
+def get_keyword_list(config, stderr, date=None, all_keywords=False):
     url = f"{config.url}/habit/keywords/mine/"
 
+    params = {}
+    if date is not None:
+        params['date'] = date.date().isoformat()
     if all_keywords:
-        url += "?all=true"
+        params['all'] = 'true'
 
-    r = requests.get(url, auth=HTTPBasicAuth(config.user, config.password))
+    r = requests.get(url, params=params, auth=HTTPBasicAuth(config.user, config.password))
 
     if r.ok:
         return [Keyword(**kw) for kw in r.json()]
@@ -92,6 +95,7 @@ def get_keyword_list(config, stderr, all_keywords=False):
             stderr.write(json.dumps(r.json(), indent=4, sort_keys=True) + '\n')
         except json.decoder.JSONDecodeError:
             stderr.write("HTTP {}\n{}".format(r.status_code, r.text) + '\n')
+        return []
 
 
 def print_habit_list(config, filename='-'):
@@ -201,7 +205,7 @@ def main():
         print_habit_list(config, arguments['--output'])
         return
 
-    keywords = get_keyword_list(config, sys.stderr, all_keywords=arguments['--all'])
+    keywords = get_keyword_list(config, sys.stderr, date=published, all_keywords=arguments['--all'])
 
     print("Tip: Use pipe separator (|) for multiple entries: y first entry | second entry | n third entry")
 

--- a/src/tasks_collector_tools/habits.py
+++ b/src/tasks_collector_tools/habits.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from dateutil.parser import parse
 
-from .models import HabitWithTracked
+from .models import HabitWithTracked, Keyword
 
 
 def add_habit(config, text, published=None):
@@ -70,6 +70,23 @@ def get_habit_list(config, stderr, date=None):
 
     if r.ok:
         return r.json()['results']
+    else:
+        try:
+            stderr.write(json.dumps(r.json(), indent=4, sort_keys=True) + '\n')
+        except json.decoder.JSONDecodeError:
+            stderr.write("HTTP {}\n{}".format(r.status_code, r.text) + '\n')
+
+
+def get_keyword_list(config, stderr, all_keywords=False):
+    url = f"{config.url}/habit/keywords/mine/"
+
+    if all_keywords:
+        url += "?all=true"
+
+    r = requests.get(url, auth=HTTPBasicAuth(config.user, config.password))
+
+    if r.ok:
+        return [Keyword(**kw) for kw in r.json()]
     else:
         try:
             stderr.write(json.dumps(r.json(), indent=4, sort_keys=True) + '\n')
@@ -183,31 +200,21 @@ def main():
     if arguments['--list']:
         print_habit_list(config, arguments['--output'])
         return
-    
-    raw_habits = get_habit_list(config, sys.stderr, date=published.date())
 
-    habits = map(lambda h: HabitWithTracked(**h), raw_habits)
-
-    def check(keyword, habit):
-        if arguments['--all']:
-            return True
-
-        return keyword not in config.ignore_habits and habit.today_tracked == 0
-
-    keywords = [keyword for habit in habits for keyword in habit.keywords if check(keyword, habit)]
+    keywords = get_keyword_list(config, sys.stderr, all_keywords=arguments['--all'])
 
     print("Tip: Use pipe separator (|) for multiple entries: y first entry | second entry | n third entry")
 
     try:
-        for keyword in keywords:
-            entries = ask_for(['y', 't'], ['n', 'f'], ['s'], prompt=f'#{keyword} {{words}}')
+        for kw in keywords:
+            entries = ask_for(['y', 't'], ['n', 'f'], ['s'], prompt=f'#{kw.keyword} {{words}}')
 
             if entries is None:
                 continue
 
             # Process all entries for this habit
             for answer, text in entries:
-                add_habit(config, format_line(keyword, answer, text), published=published)
+                add_habit(config, format_line(kw.keyword, answer, text), published=published)
     except (KeyboardInterrupt, EOFError):
         print()
         return

--- a/src/tasks_collector_tools/models.py
+++ b/src/tasks_collector_tools/models.py
@@ -26,6 +26,12 @@ class Habit(BaseModel):
 class HabitWithTracked(Habit):
     today_tracked: int
 
+
+class Keyword(BaseModel):
+    id: int
+    keyword: str
+    habit: Habit
+
 class JournalAdded(BaseEvent):
     resourcetype: Literal['JournalAdded']
     comment: str


### PR DESCRIPTION
## Summary

- Add `Keyword` Pydantic model with habit relationship
- Create `get_keyword_list()` function to fetch from new `/habit/keywords/mine/` endpoint
- Support `?all=true` query parameter for `--all` option
- Simplify `main()` by removing client-side filtering logic that's now handled server-side
- Remove `ignore_habits` filtering (tracking status now handled by the backend)

## Changes

The new endpoint returns keywords with their associated habits and handles tracking status filtering server-side. This makes the client code simpler and more efficient by:

1. Eliminating the need to fetch all habits and filter them client-side
2. Reducing data transfer (only returns relevant keywords)
3. Centralizing filtering logic in the backend

## Test plan

- [x] Test basic habit tracking workflow
- [x] Test `--all` flag to include already-tracked habits
- [x] Test `--list` flag still works correctly
- [x] Verify date filtering with `--date` and `--yesterday` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)