### PR TITLE
feat: add sjournal to tasks interactive commands

### DIFF
--- a/src/tasks_collector_tools/tasks.py
+++ b/src/tasks_collector_tools/tasks.py
@@ -206,6 +206,7 @@ commands = {
     'edit': open_observation,
     'quest': 'quest',
     'journal': 'journal',
+    'sjournal': 'sjournal',
     'thought': ['journal', '-T', 'thoughts'],
     'update': 'update',
     'help': print_help,


### PR DESCRIPTION
## Summary
- Add `sjournal` command to the tasks REPL commands dictionary
- Allows users to invoke sjournal directly from the interactive prompt

## Test plan
- [x] Run `tasks` and type `sjournal` to verify it launches the sjournal command

🤖 Generated with [Claude Code](https://claude.com/claude-code)