### PR TITLE
feat: skip request when journal content unchanged from template

### DIFF
--- a/src/tasks_collector_tools/journal.py
+++ b/src/tasks_collector_tools/journal.py
@@ -186,6 +186,15 @@ def main():
     if result.returncode != 0:
         sys.exit(1)
 
+    # Check if content is empty or unchanged from template
+    with open(tmpfile.name) as f:
+        edited_content = f.read()
+
+    if not edited_content.strip() or edited_content.strip() == template.strip():
+        print("No changes were made.")
+        os.unlink(tmpfile.name)
+        sys.exit(0)
+
     payload = {
         'comment': None,
         'thread': arguments['--thread'],


### PR DESCRIPTION
## Summary
- Add early exit check when journal content is empty or unchanged from template
- Prevents unnecessary API requests when user quits editor without making changes
- Particularly useful when using the `-f` file option

## Test plan
- [x] Run `journal -f somefile.md` and quit without changes - should exit with "No changes were made."
- [x] Run `journal` and clear all content - should exit with "No changes were made."
- [x] Run `journal` and make actual changes - should send request as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)