### PR TITLE
fix: pass date params to jira command in sjournal

### DIFF
--- a/src/tasks_collector_tools/sjournal.py
+++ b/src/tasks_collector_tools/sjournal.py
@@ -32,12 +32,19 @@ def main():
         print("Error: 'jira' command not found. Please install jira CLI first.")
         sys.exit(1)
 
+    # Build jira command with date options
+    jira_cmd = ['jira', '-l']
+    if arguments['--date']:
+        jira_cmd.extend(['-d', arguments['--date']])
+    if arguments['--yesterday']:
+        jira_cmd.append('-Y')
+
     # Run jira -l and capture output
     try:
-        result = subprocess.run(['jira', '-l'], capture_output=True, text=True)
+        result = subprocess.run(jira_cmd, capture_output=True, text=True)
         jira_output = result.stdout
     except Exception as e:
-        print(f"Error running 'jira -l': {e}")
+        print(f"Error running '{' '.join(jira_cmd)}': {e}")
         sys.exit(1)
 
     # Process jira output: prepend tasks with checkbox, skip Total line


### PR DESCRIPTION
## Summary
- Fix bug where `--date` and `-Y` parameters were only passed to the `journal` command but not to the `jira` command
- Now `sjournal -Y` and `sjournal --date DATE` correctly fetch Jira logs for the specified date

## Test plan
- [x] Run `sjournal -Y` and verify it fetches yesterday's Jira logs
- [x] Run `sjournal --date 2025-01-20` and verify it fetches logs for that date

🤖 Generated with [Claude Code](https://claude.com/claude-code)