### PR TITLE
fix: use --date long flag for jira command in sjournal

### DIFF
--- a/src/tasks_collector_tools/sjournal.py
+++ b/src/tasks_collector_tools/sjournal.py
@@ -35,7 +35,7 @@ def main():
     # Build jira command with date options
     jira_cmd = ['jira', '-l']
     if arguments['--date']:
-        jira_cmd.extend(['-d', arguments['--date']])
+        jira_cmd.extend(['--date', arguments['--date']])
     if arguments['--yesterday']:
         jira_cmd.append('-Y')
 


### PR DESCRIPTION
## Summary
- Fix incorrect short flag `-d` to long flag `--date` when passing the date option to the jira command in sjournal

## Test plan
- [x] Run `sjournal --date 2025-01-01` and verify the jira command receives the correct `--date` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)