### PR TITLE
feat: add --force flag to journal to send unchanged content

### DIFF
--- a/src/tasks_collector_tools/journal.py
+++ b/src/tasks_collector_tools/journal.py
@@ -11,6 +11,7 @@ Options:
     -Y, --yesterday  Use yesterday's date for the journal entry.
     -t THREAD, --thread THREAD  Use this thread [default: Daily]
     -f FILE, --file FILE  Use this file instead of the generated template.
+    -F, --force      Send even if content is unchanged from template.
     -L, --today      List journals from today.
     -h, --help       Show this message.
     --version        Show version information.
@@ -190,7 +191,7 @@ def main():
     with open(tmpfile.name) as f:
         edited_content = f.read()
 
-    if not edited_content.strip() or edited_content.strip() == template.strip():
+    if not edited_content.strip() or (edited_content.strip() == template.strip() and not arguments['--force']):
         print("No changes were made.")
         os.unlink(tmpfile.name)
         sys.exit(0)


### PR DESCRIPTION
## Summary
- Adds `-F` / `--force` flag to the `journal` command
- When using `--file`, the file content becomes part of the template, so the unchanged-content check blocks sending — `--force` bypasses this check
- Empty content is still blocked even with `--force`

## Test plan
- [x] Run `journal -f <file> --thread Weekly --force` and verify it sends
- [x] Run `journal` without `--force`, make no edits, and verify it still shows "No changes were made."

🤖 Generated with [Claude Code](https://claude.com/claude-code)