### PR TITLE
refactor: remove want field from Plan clients

### DIFF
--- a/src/tasks_collector_tools/eventdump.py
+++ b/src/tasks_collector_tools/eventdump.py
@@ -54,12 +54,6 @@ TEMPLATE = """
 {{ plan.focus_list }}
 {% endif %}
 
-{% if plan and plan.model.has_want %}
-## Want
-
-{{ plan.want_list }}
-{% endif %}
-
 {% if habits %}
 ## Habits
 

--- a/src/tasks_collector_tools/models.py
+++ b/src/tasks_collector_tools/models.py
@@ -151,14 +151,10 @@ class ProjectedOutcomeClosed(BaseEvent):
 class Plan(BaseModel):
     id: int
     focus: str|None
-    want: str|None
     pub_date: date
 
     def empty(self):
-        return not self.has_want() and not self.has_focus()
-
-    def has_want(self):
-        return not_empty(self.want)
+        return not self.has_focus()
 
     def has_focus(self):
         return not_empty(self.focus)

--- a/src/tasks_collector_tools/plans.py
+++ b/src/tasks_collector_tools/plans.py
@@ -12,11 +12,9 @@ from requests.exceptions import ConnectionError
 
 
 FOCUS_TEMPLATE = "Focus: {focus}"
-WANT_TEMPLATE = "Want: {want}"
 
 PLAN_TEMPLATE = """
 {focus}
-{want}
 """
 
 @dataclass
@@ -24,22 +22,17 @@ class Plan:
     id: int
     pub_date: date
     focus: str
-    want: str
 
     def __str__(self):
-        if not self.focus and not self.want:
+        if not self.focus:
             return ""
 
         focus = itemize_string(self.focus, prepend="\n", prefix="- [ ] ")
-        want = itemize_string(self.want, prepend="\n", prefix="- [ ] ")
 
         if focus.strip():
             focus = FOCUS_TEMPLATE.format(focus=focus)
-        
-        if want.strip():
-            want = WANT_TEMPLATE.format(want=want)
 
-        return PLAN_TEMPLATE.format(focus=focus, want=want).strip() + "\n"
+        return PLAN_TEMPLATE.format(focus=focus).strip() + "\n"
 
 
 def get_plan_for_today(config):
@@ -56,11 +49,11 @@ def get_plan_for_today(config):
         data = response.json()
 
         if data['count'] == 0:
-            return Plan(id=None, pub_date=date.today(), focus="", want="")
+            return Plan(id=None, pub_date=date.today(), focus="")
 
         return Plan(**data['results'][0])
     except ConnectionError:
-        return Plan(id=None, pub_date=date.today(), focus='', want='')
+        return Plan(id=None, pub_date=date.today(), focus='')
 
 def get_end_of_week(dt: date) -> date:
     """Get the date of the end of the week (Sunday) for the given date."""
@@ -86,11 +79,11 @@ async def fetch_plan(session: aiohttp.ClientSession, config, target_date: date, 
             data = await response.json()
             
             if data['count'] == 0:
-                return Plan(id=None, pub_date=target_date, focus="", want="")
+                return Plan(id=None, pub_date=target_date, focus="")
             
             return Plan(**data['results'][0])
     except (aiohttp.ClientError, asyncio.TimeoutError):
-        return Plan(id=None, pub_date=target_date, focus='', want='')
+        return Plan(id=None, pub_date=target_date, focus='')
 
 async def get_plans_for_today(config):
     """Fetch three plans in parallel:

--- a/src/tasks_collector_tools/presenters.py
+++ b/src/tasks_collector_tools/presenters.py
@@ -269,9 +269,6 @@ class BaseModelPresenter:
         self.model = model
 
 class PlanPresenter(BaseModelPresenter):
-    def want_list(self, prefix='- '):
-        return listize(self.model.want, prefix=prefix)
-    
     def focus_list(self, prefix='- '):
         return listize(self.model.focus, prefix=prefix)
 

--- a/src/tasks_collector_tools/reflectiondump.py
+++ b/src/tasks_collector_tools/reflectiondump.py
@@ -89,12 +89,6 @@ TEMPLATE = """
 {{ plans.focus }}
 {% endif %}
 
-{% if plans.want %}
-## Want
-
-{{ plans.want }}
-{% endif %}
-
 {% if habits.habit_groups %}
 # Habits
 
@@ -313,7 +307,6 @@ class ResultAggregator:
 
         return {
             'focus': '\n\n'.join(presenter.focus_list(prefix='- [ ] ') for presenter in presenters),
-            'want': '\n\n'.join(presenter.want_list(prefix='- [ ] ') for presenter in presenters),
         }
 
     def _render_events(self, events: List[Event], separator='\n'):


### PR DESCRIPTION
## Summary
- Remove the `want` field from Plan model, dataclass, presenter, and templates
- The `want` field was removed from the Plan API — only `focus` remains
- Cleans up all client-side references across 5 files

## Test plan
- [x] Verify `plans` command renders correctly with only `focus`
- [ ] Verify event dump and reflection dump templates render without `want` sections
- [ ] Confirm no remaining `want` references in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)