### PR TITLE
feat: add ProjectedOutcomeMoved event type

### DIFF
--- a/src/tasks_collector_tools/models.py
+++ b/src/tasks_collector_tools/models.py
@@ -138,6 +138,18 @@ class ProjectedOutcomeRescheduled(BaseEvent):
     new_resolved_by: Optional[datetime]
 
 
+class ProjectedOutcomeMoved(BaseEvent):
+    resourcetype: Literal['ProjectedOutcomeMoved']
+    event_stream_id: str
+    thread: str
+    name: str
+    description: Optional[str]
+    resolved_by: Optional[datetime]
+    confidence_level: Optional[str]
+    old_breakthrough: Optional[int]
+    new_breakthrough: Optional[int]
+
+
 class ProjectedOutcomeClosed(BaseEvent):
     resourcetype: Literal['ProjectedOutcomeClosed']
     event_stream_id: str
@@ -194,6 +206,7 @@ Event = Union[
     ProjectedOutcomeMade,
     ProjectedOutcomeRedefined,
     ProjectedOutcomeRescheduled,
+    ProjectedOutcomeMoved,
     ProjectedOutcomeClosed
 ]
 

--- a/src/tasks_collector_tools/presenters.py
+++ b/src/tasks_collector_tools/presenters.py
@@ -10,7 +10,7 @@ from .models import (
     ObservationMade, ObservationUpdated, ObservationRecontextualized,
     ObservationReinterpreted, ObservationReflectedUpon, ObservationClosed,
     ObservationAttached, ObservationDetached,
-    ProjectedOutcomeMade, ProjectedOutcomeRedefined, ProjectedOutcomeRescheduled, ProjectedOutcomeClosed,
+    ProjectedOutcomeMade, ProjectedOutcomeRedefined, ProjectedOutcomeRescheduled, ProjectedOutcomeMoved, ProjectedOutcomeClosed,
     Plan, Reflection, Event
 )
 
@@ -249,6 +249,15 @@ class ProjectedOutcomeRescheduledPresenter(BaseEventPresenter):
     def new_resolved_by_date(self):
         return self.event.new_resolved_by.strftime('%Y-%m-%d') if self.event.new_resolved_by else None
 
+class ProjectedOutcomeMovedPresenter(BaseEventPresenter):
+    template: str = """
+    **{{ event.name }}** moved{% if event.old_breakthrough and event.new_breakthrough %} from *{{ event.old_breakthrough }}* to *{{ event.new_breakthrough }}*{% elif event.new_breakthrough %} to *{{ event.new_breakthrough }}*{% endif %}
+    {% if event.description %}
+
+    {{ event.description }}
+    {% endif %}
+    """
+
 class ProjectedOutcomeClosedPresenter(BaseEventPresenter):
     template: str = """
     **{{ event.name }}** ✓
@@ -311,6 +320,8 @@ def get_presenter_class(event: Event):
             return ProjectedOutcomeRedefinedPresenter
         case ProjectedOutcomeRescheduled():
             return ProjectedOutcomeRescheduledPresenter
+        case ProjectedOutcomeMoved():
+            return ProjectedOutcomeMovedPresenter
         case ProjectedOutcomeClosed():
             return ProjectedOutcomeClosedPresenter
         case _:


### PR DESCRIPTION
## Summary
- Add `ProjectedOutcomeMoved` model with fields from the API serializer (`event_stream_id`, `thread`, `name`, `description`, `resolved_by`, `confidence_level`, `old_breakthrough`, `new_breakthrough`)
- Add presenter that renders breakthrough movement info
- Wire up in `Event` union and presenter factory

## Test plan
- [x] Verify `reflectiondump` parses API responses containing `ProjectedOutcomeMoved` events without validation errors
- [ ] Verify rendered output shows breakthrough movement correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)