### PR TITLE
feat: add InsightRefined event type

### DIFF
--- a/src/tasks_collector_tools/models.py
+++ b/src/tasks_collector_tools/models.py
@@ -97,6 +97,14 @@ class ObservationClosed(ObservationEvent):
     approach: Optional[str]
 
 
+class InsightRefined(ObservationEvent):
+    url: str
+    resourcetype: Literal['InsightRefined']
+    type: str
+    situation: Optional[str]
+    approach: Optional[str]
+
+
 class ObservationAttached(BaseEvent):
     resourcetype: Literal['ObservationAttached']
     other_event_stream_id: str
@@ -201,6 +209,7 @@ Event = Union[
     ObservationReinterpreted, 
     ObservationReflectedUpon, 
     ObservationClosed,
+    InsightRefined,
     ObservationAttached,
     ObservationDetached,
     ProjectedOutcomeMade,

--- a/src/tasks_collector_tools/presenters.py
+++ b/src/tasks_collector_tools/presenters.py
@@ -9,7 +9,7 @@ from .models import (
     BaseEvent, Habit, JournalAdded, HabitTracked, ObservationEvent,
     ObservationMade, ObservationUpdated, ObservationRecontextualized,
     ObservationReinterpreted, ObservationReflectedUpon, ObservationClosed,
-    ObservationAttached, ObservationDetached,
+    InsightRefined, ObservationAttached, ObservationDetached,
     ProjectedOutcomeMade, ProjectedOutcomeRedefined, ProjectedOutcomeRescheduled, ProjectedOutcomeMoved, ProjectedOutcomeClosed,
     Plan, Reflection, Event
 )
@@ -188,6 +188,18 @@ class ObservationClosedPresenter(BaseEventPresenter):
     {% endif %}
     """
 
+class InsightRefinedPresenter(BaseEventPresenter):
+    template: str = """
+    {% if event.situation %}
+    {{ event.situation }}
+    {% endif %}
+    {% if event.approach %}
+    ### Approach
+
+    {{ event.approach }}
+    {% endif %}
+    """
+
 class ObservationAttachedPresenter(BaseEventPresenter):
     template: str = """
     Attached observation {{ observation_ref }} to thread {{ event.thread }}
@@ -310,6 +322,8 @@ def get_presenter_class(event: Event):
             return ObservationReflectedUponPresenter
         case ObservationClosed():
             return ObservationClosedPresenter
+        case InsightRefined():
+            return InsightRefinedPresenter
         case ObservationAttached():
             return ObservationAttachedPresenter
         case ObservationDetached():


### PR DESCRIPTION
## Summary
- Add `InsightRefined` Pydantic model as an `ObservationEvent` subclass with `url`, `type`, `situation`, and `approach` fields
- Add `InsightRefinedPresenter` for rendering the new event type
- Register the new type in the `Event` union and presenter factory

## Test plan
- [x] Run `eventdump` against API data containing `InsightRefined` events
- [x] Run `reflectiondump` against API data containing `InsightRefined` events
- [x] Verify observations stats correctly include `InsightRefined` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)