### PR TITLE
feat: add ProjectedOutcomeEvolved event type

### DIFF
--- a/src/tasks_collector_tools/models.py
+++ b/src/tasks_collector_tools/models.py
@@ -168,6 +168,13 @@ class ProjectedOutcomeClosed(BaseEvent):
     success_criteria: Optional[str]
 
 
+class ProjectedOutcomeEvolved(BaseEvent):
+    resourcetype: Literal['ProjectedOutcomeEvolved']
+    event_stream_id: str
+    thread: str
+    note: str
+
+
 class Plan(BaseModel):
     id: int
     focus: str|None
@@ -216,7 +223,8 @@ Event = Union[
     ProjectedOutcomeRedefined,
     ProjectedOutcomeRescheduled,
     ProjectedOutcomeMoved,
-    ProjectedOutcomeClosed
+    ProjectedOutcomeClosed,
+    ProjectedOutcomeEvolved
 ]
 
 class DefaultBoardThread(BaseModel):

--- a/src/tasks_collector_tools/presenters.py
+++ b/src/tasks_collector_tools/presenters.py
@@ -10,7 +10,7 @@ from .models import (
     ObservationMade, ObservationUpdated, ObservationRecontextualized,
     ObservationReinterpreted, ObservationReflectedUpon, ObservationClosed,
     InsightRefined, ObservationAttached, ObservationDetached,
-    ProjectedOutcomeMade, ProjectedOutcomeRedefined, ProjectedOutcomeRescheduled, ProjectedOutcomeMoved, ProjectedOutcomeClosed,
+    ProjectedOutcomeMade, ProjectedOutcomeRedefined, ProjectedOutcomeRescheduled, ProjectedOutcomeMoved, ProjectedOutcomeClosed, ProjectedOutcomeEvolved,
     Plan, Reflection, Event
 )
 
@@ -278,10 +278,15 @@ class ProjectedOutcomeClosedPresenter(BaseEventPresenter):
     {{ event.description }}
     {% endif %}
     {% if event.success_criteria %}
-    
+
     ### Success Criteria
     {{ event.success_criteria }}
     {% endif %}
+    """
+
+class ProjectedOutcomeEvolvedPresenter(BaseEventPresenter):
+    template: str = """
+    {{ event.note }}
     """
 
 # Presenter classes for Plan and Reflection
@@ -338,6 +343,8 @@ def get_presenter_class(event: Event):
             return ProjectedOutcomeMovedPresenter
         case ProjectedOutcomeClosed():
             return ProjectedOutcomeClosedPresenter
+        case ProjectedOutcomeEvolved():
+            return ProjectedOutcomeEvolvedPresenter
         case _:
             return BaseEventPresenter
 


### PR DESCRIPTION
## Summary
- Add `ProjectedOutcomeEvolved` pydantic event model (with `event_stream_id`, `thread`, `note`) so the parser no longer breaks on this resourcetype from the backend
- Wire up `ProjectedOutcomeEvolvedPresenter` rendering the note under the standard event heading

## Test plan
- [x] Fetch a feed containing a `ProjectedOutcomeEvolved` event and confirm parsing succeeds
- [ ] Confirm the rendered output shows `### HH:MM: ProjectedOutcomeEvolved` followed by the note text

🤖 Generated with [Claude Code](https://claude.com/claude-code)