### PR TITLE
feat: simplified daily reflect flow with quoted journal entries

### DIFF
--- a/src/tasks_collector_tools/reflect.py
+++ b/src/tasks_collector_tools/reflect.py
@@ -219,6 +219,41 @@ def fill_missing_journal_entries(arguments):
         print(f"Error running reflectiondump: {e}")
 
 
+def is_daily_mode(arguments):
+    return not arguments['--week'] and not arguments['--month']
+
+
+def daily_reflection(arguments):
+    """Dump quoted journal entries straight into `journal` — no editor opened here."""
+    day = parse(arguments['--date']).date() if arguments['--date'] else date.today()
+
+    if arguments['--yesterday']:
+        day = day - timedelta(days=1)
+
+    cmd = [
+        'reflectiondump',
+        '--no-summary',
+        '--no-titles',
+        '--no-habits',
+        '--no-observations',
+        '--prefix', '> ',
+        '-d', day.strftime('%Y-%m-%d'),
+        '-D', day.strftime('%Y-%m-%d'),
+    ]
+
+    output = subprocess.check_output(cmd).decode('utf-8').strip().replace('\r', '')
+
+    published = published_from_arguments(arguments)
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.md') as f:
+        f.write(output)
+        f.flush()
+
+        journal_cmd = ['journal', '--date', published.isoformat(), '--file', f.name]
+
+        subprocess.run(journal_cmd, check=True)
+
+
 def get_journal_command_arguments_from_payload(payload):
     """Convert a reflection payload into journal command arguments."""
     cmd = ['journal']
@@ -242,6 +277,10 @@ def main():
     
     if arguments['--missing']:
         fill_missing_journal_entries(arguments)
+
+    if is_daily_mode(arguments):
+        daily_reflection(arguments)
+        return
 
     tmpfile = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.md')
 

--- a/src/tasks_collector_tools/reflectiondump.py
+++ b/src/tasks_collector_tools/reflectiondump.py
@@ -6,6 +6,11 @@ Usage:
 Options:
     -T, --thread THREAD  Dump specific thread.
     --skip-journals     Skip journals.
+    --no-summary        Skip Good/Better/Best summary.
+    --no-titles         Skip section headers ("# Reflection", "# Journals", etc).
+    --no-habits         Skip habits section.
+    --no-observations   Skip observations section.
+    --prefix PREFIX     Prefix each line of journal entries with PREFIX.
     -d DATE_FROM, --from FROM  Dump from specific date.
     -D DATE_TO, --to DATE_TO   Dump to specific date.
     --year YEAR      Dump specific year.
@@ -67,40 +72,38 @@ EVENT_TEMPLATE = """
 
 
 TEMPLATE = """
-# {{ title }}
-{% if reflections.good %}
+{{ title }}
+{% if show_summary %}
 {{ reflections.good }}
-{% endif %}
 
-## Better
-{% if reflections.better %}
+{{ better_header }}
+
 {{ reflections.better }}
-{% endif %}
 
-## Best
-{% if reflections.best %}
+{{ best_header }}
+
 {{ reflections.best }}
 {% endif %}
 
 {% if has_plans %}
-# Plans
+{{ plans_header }}
 {% endif %}
 {% if plans.focus %}
 {{ plans.focus }}
 {% endif %}
 
 {% if habits.habit_groups %}
-# Habits
+{{ habits_header }}
 
 {{ habits.habit_groups }}
 {% endif %}
 {% if observation_stats.count %}
-# Work on observations ({{ observation_stats.count }})
+{{ observations_header }}
 
 {{ observation_stats.renders }}
 {% endif %}
 {% if journals %}
-# Journals
+{{ journals_header }}
 
 {{ journals }}
 {% endif %}
@@ -115,6 +118,7 @@ def first_line(text):
     return text
 
 TIME_FORMAT = '(%a) %H:%M'
+DAILY_TIME_FORMAT = '%H:%M'
 
 
 def parse_result(result_data: dict) -> Result:
@@ -269,9 +273,14 @@ class HabitStatistics:
 class ResultAggregator:
     results: List[Result]
 
-    def __init__(self, results: List[Result], skip_journals: bool = False):
+    def __init__(self, results: List[Result], skip_journals: bool = False, skip_summary: bool = False, skip_titles: bool = False, skip_habits: bool = False, skip_observations: bool = False, journal_prefix: str = ''):
         self.results = results
         self.skip_journals = skip_journals
+        self.skip_summary = skip_summary
+        self.skip_titles = skip_titles
+        self.skip_habits = skip_habits
+        self.skip_observations = skip_observations
+        self.journal_prefix = journal_prefix
 
     def _get_events(self, event_type: Type[Event]):
         return [event for result in self.results for event in result.events if isinstance(event, event_type)]
@@ -310,13 +319,17 @@ class ResultAggregator:
         }
 
     def _render_events(self, events: List[Event], separator='\n'):
-        return separator.join(get_presenter(event, time_format=TIME_FORMAT).render() for event in events)
+        time_format = DAILY_TIME_FORMAT if len(self.results) == 1 else TIME_FORMAT
+        return separator.join(get_presenter(event, time_format=time_format).render() for event in events)
 
     def render_habit_events(self):
         return self._render_events(self.get_habit_events())
     
     def render_journal_events(self):
-        return self._render_events(self.get_journal_events())
+        rendered = self._render_events(self.get_journal_events()).strip('\n')
+        if self.journal_prefix and rendered:
+            rendered = '\n'.join(self.journal_prefix + line for line in rendered.split('\n'))
+        return rendered
 
     def get_title(self):
         if len(self.results) == 0:
@@ -335,14 +348,26 @@ class ResultAggregator:
     def get_context(self):
         has_plans = any(result.plan for result in self.results)
 
+        habits = {'habit_groups': ''} if self.skip_habits else HabitStatistics(self.get_habit_events()).get_context()
+        observation_stats = {'count': 0, 'renders': ''} if self.skip_observations else self.get_observation_stats().get_context()
+
+        show_titles = not self.skip_titles
+
         return {
-            'title': self.get_title(),
+            'title': ('# ' + self.get_title()) if show_titles else '',
+            'better_header': '## Better' if show_titles else '',
+            'best_header': '## Best' if show_titles else '',
+            'plans_header': '# Plans' if show_titles else '',
+            'habits_header': '# Habits' if show_titles else '',
+            'observations_header': f'# Work on observations ({observation_stats["count"]})' if show_titles else '',
+            'journals_header': '# Journals' if show_titles else '',
+            'show_summary': not self.skip_summary,
             'reflections': self.get_reflection_context(),
             'has_plans': has_plans,
             'plans': self.get_plan_context(),
-            'habits': HabitStatistics(self.get_habit_events()).get_context(),
+            'habits': habits,
             'journals': self.render_journal_events() if not self.skip_journals else None,
-            'observation_stats': self.get_observation_stats().get_context(),
+            'observation_stats': observation_stats,
         }
 
 
@@ -392,7 +417,15 @@ def main():
     valid_results = [result for _, result in date_results 
                     if result is not None and not result.empty()]
     
-    aggregator = ResultAggregator(valid_results, skip_journals=arguments['--skip-journals'])
+    aggregator = ResultAggregator(
+        valid_results,
+        skip_journals=arguments['--skip-journals'],
+        skip_summary=arguments['--no-summary'],
+        skip_titles=arguments['--no-titles'],
+        skip_habits=arguments['--no-habits'],
+        skip_observations=arguments['--no-observations'],
+        journal_prefix=arguments['--prefix'] or '',
+    )
     print(render_template(TEMPLATE, aggregator.get_context()))
 
 


### PR DESCRIPTION
## Summary
- Split `reflect` into two first-class flows. Daily (today, `--yesterday`, `--date`) now dumps the day's journal entries via `reflectiondump` and pipes them straight into `journal --file` — no editor opened by `reflect` itself, so the user only edits once. Weekly/monthly keep the existing pick-`[x]` workflow untouched.
- `reflectiondump` gains `--no-summary`, `--no-titles`, `--no-habits`, `--no-observations`, and `--prefix PREFIX`. The daily flow uses all of these to produce a clean `> `-quoted block of journal entries for bottom-posting style reflection.
- Headers are routed through context variables so `--no-titles` drops them all without introducing nested `{% if %}` blocks (the template helper's regex isn't nesting-aware).
- `render_journal_events` strips leading/trailing newlines before prefixing so the quoted block has no stray `> ` lines.
- When the dump covers a single day (`len(results) == 1`), the time format compacts from `(%a) %H:%M` to `%H:%M` — matches the convention `get_title` already uses.

## Test plan
- [x] `reflect` (today): opens `journal` directly with today's quoted entries, no second editor
- [x] `reflect --yesterday`: same, with yesterday's date and entries
- [ ] `reflect --date 2026-05-01`: same, for the given date
- [x] `reflect --week`: existing checkbox-pick workflow still works
- [ ] `reflect --month`: existing checkbox-pick workflow still works
- [x] `reflectiondump --no-summary` drops Good/Better/Best block
- [x] `reflectiondump --no-titles` drops every section header
- [x] `reflectiondump --prefix '> '` quotes journal entries cleanly with no stray `> ` at top/bottom
- [x] Single-day dump shows `HH:MM`; multi-day dump shows `(Mon) HH:MM`