### PR TITLE
feat: attach journal entries to a story

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
             'tasks = tasks_collector_tools.tasks:main',
             'update = tasks_collector_tools.update:main',
             'journal = tasks_collector_tools.journal:main',
+            'tjournal = tasks_collector_tools.journal:trip_main',
+            'tripjournal = tasks_collector_tools.journal:trip_main',
             'habits = tasks_collector_tools.habits:main',
             'eventdump = tasks_collector_tools.eventdump:main',
             'reflectiondump = tasks_collector_tools.reflectiondump:main',

--- a/src/tasks_collector_tools/journal.py
+++ b/src/tasks_collector_tools/journal.py
@@ -12,6 +12,7 @@ Options:
     -t THREAD, --thread THREAD  Use this thread [default: Daily]
     -S ID, --story ID  Attach this journal entry to story ID.
     --active-story   Attach to the currently active story (overridden by --story).
+    --current-trip   Attach to the saved current trip (see the `trip` command).
     -f FILE, --file FILE  Use this file instead of the generated template.
     -F, --force      Send even if content is unchanged from template.
     -L, --today      List journals from today.
@@ -61,7 +62,7 @@ from .config.tasks import TasksConfigFile
 from .quick_notes import get_quick_notes_as_string
 
 from .plans import get_plans_for_today_sync
-from .story import get_active_story
+from .story import get_active_story, get_current_trip, get_story
 from .utils import sanitize_fields, get_cursor_position, sanitize_list_of_strings, queue_failed_request, retry_failed_requests
 
 def yesterdays_date():
@@ -178,16 +179,25 @@ def list_todays_journals(arguments):
 def resolve_story_from_arguments(arguments, config):
     """Resolve the story to pre-fill into the template, or None.
 
-    `--story ID` is explicit and wins (title unknown, so the line shows just
-    the id). `--active-story` fetches the currently active story from the
-    backend; if none is active it prints a notice and returns None.
+    Priority: `--story ID` (explicit) > `--current-trip` (saved by the `trip`
+    command) > `--active-story` (newest active story from the backend). The
+    id is looked up so the meta line can show the title; if the lookup fails
+    we fall back to an id-only dict so the link still works offline.
     """
     if arguments['--story']:
         try:
-            return {'id': int(arguments['--story'])}
+            story_id = int(arguments['--story'])
         except ValueError:
             print(f"Ignoring invalid --story value: {arguments['--story']}")
             return None
+        return get_story(config, story_id) or {'id': story_id}
+
+    if arguments['--current-trip']:
+        story_id = get_current_trip()
+        if story_id is None:
+            print("No current trip set. Use the `trip` command to choose one.")
+            return None
+        return get_story(config, story_id) or {'id': story_id}
 
     if arguments['--active-story']:
         story = get_active_story(config)
@@ -198,8 +208,8 @@ def resolve_story_from_arguments(arguments, config):
     return None
 
 
-def main():
-    arguments = docopt(__doc__, version='1.1')
+def main(argv=None):
+    arguments = docopt(__doc__, version='1.1', argv=argv)
 
     config = TasksConfigFile()
 
@@ -345,6 +355,11 @@ def main():
         print("The temporary file was saved at {}".format(
             tmpfile.name
         ))
+
+
+def trip_main():
+    """Entry point for `tjournal`/`tripjournal`: journal into the current trip."""
+    main(argv=['--current-trip'] + sys.argv[1:])
 
 
 

--- a/src/tasks_collector_tools/journal.py
+++ b/src/tasks_collector_tools/journal.py
@@ -10,6 +10,8 @@ Options:
     -o               Alias for -s.
     -Y, --yesterday  Use yesterday's date for the journal entry.
     -t THREAD, --thread THREAD  Use this thread [default: Daily]
+    -S ID, --story ID  Attach this journal entry to story ID.
+    --active-story   Attach to the currently active story (overridden by --story).
     -f FILE, --file FILE  Use this file instead of the generated template.
     -F, --force      Send even if content is unchanged from template.
     -L, --today      List journals from today.
@@ -21,7 +23,7 @@ TEMPLATE = """
 > Thread: {thread}
 > Published: {published}
 > Tags: {tags}
-{notes}
+{story}{notes}
 
 {plans}
 
@@ -59,6 +61,7 @@ from .config.tasks import TasksConfigFile
 from .quick_notes import get_quick_notes_as_string
 
 from .plans import get_plans_for_today_sync
+from .story import get_active_story
 from .utils import sanitize_fields, get_cursor_position, sanitize_list_of_strings, queue_failed_request, retry_failed_requests
 
 def yesterdays_date():
@@ -83,7 +86,20 @@ def format_plan(plan, title):
         return ""
     return f"# {title}\n{plan_str}\n"
 
-def template_from_arguments(arguments, quick_notes, plans, comment=''):
+
+def story_meta_line(story):
+    """Render the editable `> Story:` meta line, or '' when there's no story.
+
+    `story` is a dict like {'id': 42, 'title': 'My Trip'} or None.
+    """
+    if not story:
+        return ""
+    title = story.get('title')
+    if title:
+        return f"> Story: {story['id']} ({title})\n"
+    return f"> Story: {story['id']}\n"
+
+def template_from_arguments(arguments, quick_notes, plans, comment='', story=None):
     # Format each plan section
     plan_sections = []
     
@@ -109,6 +125,7 @@ def template_from_arguments(arguments, quick_notes, plans, comment=''):
         thread=arguments['--thread'],
         notes=quick_notes,
         plans=plans_text,
+        story=story_meta_line(story),
     ).lstrip()
 
 
@@ -117,17 +134,25 @@ def template_from_payload(payload):
 
     payload['tags'] = ', '.join(payload['tags'])
 
-    return TEMPLATE.format(notes='', plans='', **payload).lstrip()
+    # `story` is write-only on the API, so the response never carries it.
+    return TEMPLATE.format(notes='', plans='', story='', **payload).lstrip()
 
 title_re = re.compile(r'^# (Comment)')
-meta_re = re.compile(r'^> (Thread|Published|Tags): (.*)$')
+meta_re = re.compile(r'^> (Thread|Published|Tags|Story): (.*)$')
 
 
 def add_meta_to_payload(payload, name, item):
-    if name.lower() == 'tags':
-        item = item.split(',')
+    name = name.lower()
 
-    payload[name.lower()] = item
+    if name == 'tags':
+        item = item.split(',')
+    elif name == 'story':
+        # Keep only the leading integer id; the optional "(title)" suffix is
+        # for the human writer. A blank/non-numeric value means "no story".
+        m = re.match(r'^\s*(\d+)', item)
+        item = int(m.group(1)) if m else None
+
+    payload[name] = item
 
 def add_stack_to_payload(payload, name, lines):
     payload[name.lower()] = ''.join(lines).strip()
@@ -150,6 +175,29 @@ def list_todays_journals(arguments):
         print(f"Error running reflectiondump: {e}")
         sys.exit(1)
 
+def resolve_story_from_arguments(arguments, config):
+    """Resolve the story to pre-fill into the template, or None.
+
+    `--story ID` is explicit and wins (title unknown, so the line shows just
+    the id). `--active-story` fetches the currently active story from the
+    backend; if none is active it prints a notice and returns None.
+    """
+    if arguments['--story']:
+        try:
+            return {'id': int(arguments['--story'])}
+        except ValueError:
+            print(f"Ignoring invalid --story value: {arguments['--story']}")
+            return None
+
+    if arguments['--active-story']:
+        story = get_active_story(config)
+        if story is None:
+            print("No active story found.")
+        return story
+
+    return None
+
+
 def main():
     arguments = docopt(__doc__, version='1.1')
 
@@ -160,8 +208,10 @@ def main():
         return
 
     quick_notes = get_quick_notes_as_string(config)
-    
+
     plans = get_plans_for_today_sync(config)
+
+    story = resolve_story_from_arguments(arguments, config)
 
     tmpfile = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.md')
 
@@ -170,8 +220,8 @@ def main():
     if arguments['--file']:
         with open(arguments['--file'], 'r') as f:
            comment = f.read()
-    
-    template = template_from_arguments(arguments, quick_notes, plans, comment)
+
+    template = template_from_arguments(arguments, quick_notes, plans, comment, story=story)
 
     cursor_position = get_cursor_position(template, "# Comment")
 
@@ -223,6 +273,7 @@ def main():
 
     payload = sanitize_fields(payload, {
         'tags': sanitize_list_of_strings,
+        'story': lambda v: v,  # already an int (or None); not a string to strip
     })
 
     if not payload['comment']:

--- a/src/tasks_collector_tools/story.py
+++ b/src/tasks_collector_tools/story.py
@@ -1,0 +1,33 @@
+import requests
+from requests.auth import HTTPBasicAuth
+
+from requests.exceptions import ConnectionError, ReadTimeout
+
+from .utils import SHORT_TIMEOUT
+
+
+def get_active_story(config):
+    """Return the newest active story as a dict {id, title, ...} or None.
+
+    "Active" means a story with no `stopped` timestamp. The backend orders
+    stories newest-first, so the first result is the most recently started.
+    Network failures degrade to None so the journal still opens.
+    """
+    try:
+        url = '{}/stories/?active=true'.format(config.url)
+
+        r = requests.get(
+            url,
+            auth=HTTPBasicAuth(config.user, config.password),
+            timeout=SHORT_TIMEOUT
+        )
+
+        if not r.ok:
+            return None
+
+        results = r.json().get('results', [])
+
+        return results[0] if results else None
+
+    except (ConnectionError, ReadTimeout):
+        return None

--- a/src/tasks_collector_tools/story.py
+++ b/src/tasks_collector_tools/story.py
@@ -1,17 +1,20 @@
+import os
+
 import requests
 from requests.auth import HTTPBasicAuth
 
 from requests.exceptions import ConnectionError, ReadTimeout
 
-from .utils import SHORT_TIMEOUT
+from .utils import SHORT_TIMEOUT, ensure_directory_exists
+
+CURRENT_TRIP_FILE = os.path.expanduser(os.path.join('~', '.tasks', 'current_trip'))
 
 
-def get_active_story(config):
-    """Return the newest active story as a dict {id, title, ...} or None.
+def get_active_stories(config):
+    """Return the list of active stories (dicts), newest first; [] on error.
 
-    "Active" means a story with no `stopped` timestamp. The backend orders
-    stories newest-first, so the first result is the most recently started.
-    Network failures degrade to None so the journal still opens.
+    "Active" means a story with no `stopped` timestamp. Network failures
+    degrade to an empty list so callers keep working offline.
     """
     try:
         url = '{}/stories/?active=true'.format(config.url)
@@ -23,11 +26,58 @@ def get_active_story(config):
         )
 
         if not r.ok:
-            return None
+            return []
 
-        results = r.json().get('results', [])
-
-        return results[0] if results else None
+        return r.json().get('results', [])
 
     except (ConnectionError, ReadTimeout):
+        return []
+
+
+def get_active_story(config):
+    """Return the newest active story as a dict {id, title, ...} or None."""
+    stories = get_active_stories(config)
+
+    return stories[0] if stories else None
+
+
+def get_story(config, story_id):
+    """Fetch a single story by id as a dict, or None on any failure."""
+    try:
+        url = '{}/stories/{}/'.format(config.url, story_id)
+
+        r = requests.get(
+            url,
+            auth=HTTPBasicAuth(config.user, config.password),
+            timeout=SHORT_TIMEOUT
+        )
+
+        if not r.ok:
+            return None
+
+        return r.json()
+
+    except (ConnectionError, ReadTimeout):
+        return None
+
+
+def set_current_trip(story_id):
+    """Persist the chosen trip id to ~/.tasks/current_trip."""
+    ensure_directory_exists(CURRENT_TRIP_FILE)
+
+    with open(CURRENT_TRIP_FILE, 'w') as f:
+        f.write(str(story_id))
+
+
+def get_current_trip():
+    """Return the saved current trip id (int) or None if unset/unreadable."""
+    try:
+        with open(CURRENT_TRIP_FILE) as f:
+            text = f.read().strip()
+    except (FileNotFoundError, OSError):
+        return None
+
+    try:
+        return int(text)
+    except ValueError:
         return None

--- a/src/tasks_collector_tools/tasks.py
+++ b/src/tasks_collector_tools/tasks.py
@@ -48,6 +48,7 @@ except ImportError:
 from .quick_notes import get_quick_notes_as_string
 from .habits import add_habit
 from .plans import get_plan_for_today
+from .story import get_active_stories, set_current_trip
 
 import re
 
@@ -197,6 +198,46 @@ def show_stats(args, config):
         print(f"Error fetching stats: {e}", file=sys.stderr)
 
 
+def select_trip(args, config):
+    """Set the current trip, saved to ~/.tasks/current_trip.
+
+    With an id argument, save it directly. Without one, list the active
+    trips: auto-select when there's exactly one, otherwise prompt for a
+    1-N choice. `tjournal`/`tripjournal` then journal into this trip.
+    """
+    if args:
+        try:
+            story_id = int(args[0])
+        except ValueError:
+            print(f"Invalid trip id: {args[0]}")
+            return
+
+        set_current_trip(story_id)
+        print(f"Current trip set to #{story_id}.")
+        return
+
+    stories = get_active_stories(config)
+
+    if not stories:
+        print("No active trips found. Use `trip <id>` to set one explicitly.")
+        return
+
+    for i, s in enumerate(stories, 1):
+        print(f"  {i}. #{s['id']} {s.get('title') or ''}".rstrip())
+
+    if len(stories) == 1:
+        story = stories[0]
+    else:
+        choice = get_input_until(
+            lambda t: t.isdigit() and 1 <= int(t) <= len(stories),
+            prompt=f"Pick a trip (1-{len(stories)}): ",
+        )
+        story = stories[int(choice) - 1]
+
+    set_current_trip(story['id'])
+    print(f"Current trip set to #{story['id']} {story.get('title') or ''}".rstrip())
+
+
 commands = {
     'observation': 'observation',
     'olist': ['observation', '-l'],
@@ -207,6 +248,9 @@ commands = {
     'quest': 'quest',
     'journal': 'journal',
     'sjournal': 'sjournal',
+    'trip': select_trip,
+    'tjournal': ['journal', '--current-trip'],
+    'tripjournal': ['journal', '--current-trip'],
     'thought': ['journal', '-T', 'thoughts'],
     'update': 'update',
     'help': print_help,


### PR DESCRIPTION
## Summary
- Adds the ability to attach a journal entry to a story via `-S/--story ID` or `--active-story`.
- Renders an editable `> Story:` meta line in the journal template; the optional `(title)` suffix is for the human writer and is ignored on parse.
- Adds `story.py` with `get_active_story`, which queries the backend's `/stories/?active=true` endpoint and returns the newest active story (or `None`).

## Details
- `--story ID` is explicit and wins; the meta line shows just the id since the title is unknown.
- `--active-story` fetches the currently active story from the backend; if none is active it prints a notice and continues without a story.
- Network failures (connection errors / timeouts) degrade gracefully to `None` so the journal still opens.
- The `story` field is write-only on the API, so it is omitted when rebuilding the template from an API payload response.
- Only the leading integer id is parsed from the meta line; a blank/non-numeric value means "no story".

## Test plan
- [ ] `journal -S 42` pre-fills `> Story: 42` in the template.
- [ ] `journal --active-story` pre-fills the active story (id + title), or prints "No active story found." when there is none.
- [ ] Editing/clearing the `> Story:` line is reflected in the submitted payload.
- [ ] Backend unreachable → journal still opens with no story line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)